### PR TITLE
Add missing shebang to autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 autoreconf -i --force


### PR DESCRIPTION
This was causing build failures on Alpine Linux on aarch64, worked fine on x86_64 however.